### PR TITLE
Fix: Replace window.close() with dialog hiding functionality

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -57,14 +57,24 @@
         .dialog button:hover {
             background-color: #0056b3;
         }
+
+        .hidden {
+            display: none;
+        }
     </style>
 </head>
 <body>
-    <div class="dialog-overlay">
+    <div class="dialog-overlay" id="dialogOverlay">
         <div class="dialog">
             <h1>Hello World!</h1>
-            <button onclick="window.close()">Chiudi</button>
+            <button onclick="closeDialog()">Chiudi</button>
         </div>
     </div>
+
+    <script>
+        function closeDialog() {
+            document.getElementById('dialogOverlay').classList.add('hidden');
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
The Chiudi button now hides the dialog overlay using CSS instead of calling window.close(), which only works for windows opened via JavaScript. This solution will work when users open http://localhost:3000 directly in their browser.

Changes:
- Added .hidden CSS class to hide elements
- Added id to dialog-overlay div
- Replaced window.close() with closeDialog() function
- closeDialog() adds .hidden class to hide the dialog

Fixes #8